### PR TITLE
git ignored derby.log file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ test-output
 .DS_Store
 .idea
 *.iml
+*/derby.log
 dependency-reduced-pom.xml


### PR DESCRIPTION
Built locally and noticed a stray test file at:

kite-apps-examples/derby.log

I believe this has to do with the Hive DatasetRepository creating a derby DB for the metastore.  Kite proper has the same issue I believe.
