### PR TITLE
Support naming the Crunch pipelines.

### DIFF
--- a/kite-apps-crunch/src/main/java/org/kitesdk/apps/crunch/AbstractCrunchJob.java
+++ b/kite-apps-crunch/src/main/java/org/kitesdk/apps/crunch/AbstractCrunchJob.java
@@ -10,6 +10,6 @@ import org.apache.crunch.impl.mr.MRPipeline;
 public abstract class AbstractCrunchJob extends AbstractSchedulableJob {
 
   protected Pipeline getPipeline() {
-    return new MRPipeline(AbstractCrunchJob.class, getConf());
+    return new MRPipeline(AbstractCrunchJob.class, getName(), getConf());
   }
 }


### PR DESCRIPTION
Currently some teams have standard naming conventions for the Crunch Pipelines to help with other tooling.  Allowing pipeline to be named based on the SchedulableJob seems like a good way to support this convention.
