### PR TITLE
Remove the maven warnings you see when you kick off the build.

### DIFF
--- a/kite-apps-core/pom.xml
+++ b/kite-apps-core/pom.xml
@@ -190,16 +190,6 @@
     </dependency>
 
     <!-- Test Dependencies -->
-
-    <dependency>
-      <groupId>org.kitesdk</groupId>
-      <artifactId>kite-data-core</artifactId>
-      <version>${kite.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/kite-apps-examples/pom.xml
+++ b/kite-apps-examples/pom.xml
@@ -70,16 +70,6 @@
           </compilerArgs>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration> <!-- remove this once org.kitesdk.data.PartitionKey has been removed -->
-          <compilerArgs>
-            <arg>-Xlint:unchecked</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/kite-apps-spark/pom.xml
+++ b/kite-apps-spark/pom.xml
@@ -54,10 +54,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,13 @@
     <artifact.hbase-test-deps>kite-hbase-cdh5-test-dependencies</artifact.hbase-test-deps>
 
     <vers.rat>0.9</vers.rat>
+    <vers.enforcer>1.4</vers.enforcer>
+    <vers.shade>2.4.1</vers.shade>
+    <vers.jar>2.6</vers.jar>
+    <vers.javadoc>2.10.3</vers.javadoc>
+    <vers.source>2.4</vers.source>
+    <vers.compiler>3.3</vers.compiler>
+    <vers.findbugs>3.0.1</vers.findbugs>
     <vers.junit>4.10</vers.junit>
     <vers.maven-surefire-plugin>2.14.1</vers.maven-surefire-plugin>
     <vers.jodatime>2.3</vers.jodatime>
@@ -479,6 +486,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
+          <version>${vers.compiler}</version>
           <configuration>
             <source>1.6</source>
             <target>${targetJavaVersion}</target>
@@ -536,6 +544,36 @@
             </excludes>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${vers.enforcer}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>${vers.source}</version>
+        </plugin>        
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${vers.javadoc}</version>
+        </plugin>                
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>${vers.shade}</version>
+        </plugin>                
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${vers.jar}</version>
+        </plugin> 
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>findbugs-maven-plugin</artifactId>
+          <version>${vers.jar}</version>
+        </plugin> 
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
When you kick off a mvn build you often see a lot of warnings...

```
$ mvn clean
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.kitesdk:kite-apps-core:jar:0.1.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.kitesdk:kite-data-core:test-jar -> version ${kite.version} vs (?) @ org.kitesdk:kite-apps-core:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-core/pom.xml, line 215, column 17
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ org.kitesdk:kite-apps-core:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-core/pom.xml, line 74, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ org.kitesdk:kite-apps-core:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-core/pom.xml, line 78, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ org.kitesdk:kite-apps-core:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-core/pom.xml, line 36, column 15
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:findbugs-maven-plugin is missing. @ org.kitesdk:kite-apps-core:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-core/pom.xml, line 90, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-enforcer-plugin is missing. @ org.kitesdk:kite-apps:0.1.0-SNAPSHOT, /Users/mw010351/git/kite-apps/pom.xml, line 468, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.kitesdk:kite-apps-core:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-core/pom.xml, line 82, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ org.kitesdk:kite-apps-core:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-core/pom.xml, line 45, column 15
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.kitesdk:kite-apps-crunch:jar:0.1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ org.kitesdk:kite-apps-crunch:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-crunch/pom.xml, line 48, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ org.kitesdk:kite-apps-crunch:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-crunch/pom.xml, line 52, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ org.kitesdk:kite-apps-crunch:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-crunch/pom.xml, line 35, column 15
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:findbugs-maven-plugin is missing. @ org.kitesdk:kite-apps-crunch:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-crunch/pom.xml, line 64, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-enforcer-plugin is missing. @ org.kitesdk:kite-apps:0.1.0-SNAPSHOT, /Users/mw010351/git/kite-apps/pom.xml, line 468, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.kitesdk:kite-apps-crunch:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-crunch/pom.xml, line 56, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ org.kitesdk:kite-apps-crunch:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-crunch/pom.xml, line 44, column 15
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.kitesdk:kite-apps-spark:jar:0.1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-jar-plugin @ org.kitesdk:kite-apps-spark:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-spark/pom.xml, line 55, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ org.kitesdk:kite-apps-spark:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-spark/pom.xml, line 59, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ org.kitesdk:kite-apps-spark:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-spark/pom.xml, line 63, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ org.kitesdk:kite-apps-spark:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-spark/pom.xml, line 35, column 15
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:findbugs-maven-plugin is missing. @ org.kitesdk:kite-apps-spark:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-spark/pom.xml, line 75, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-enforcer-plugin is missing. @ org.kitesdk:kite-apps:0.1.0-SNAPSHOT, /Users/mw010351/git/kite-apps/pom.xml, line 468, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.kitesdk:kite-apps-spark:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-spark/pom.xml, line 67, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ org.kitesdk:kite-apps-spark:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-spark/pom.xml, line 55, column 15
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.kitesdk:kite-apps-examples:jar:0.1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-compiler-plugin @ org.kitesdk:kite-apps-examples:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-examples/pom.xml, line 74, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ org.kitesdk:kite-apps-examples:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-examples/pom.xml, line 94, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ org.kitesdk:kite-apps-examples:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-examples/pom.xml, line 98, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ org.kitesdk:kite-apps-examples:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-examples/pom.xml, line 74, column 15
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:findbugs-maven-plugin is missing. @ org.kitesdk:kite-apps-examples:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-examples/pom.xml, line 110, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-enforcer-plugin is missing. @ org.kitesdk:kite-apps:0.1.0-SNAPSHOT, /Users/mw010351/git/kite-apps/pom.xml, line 468, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.kitesdk:kite-apps-examples:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-examples/pom.xml, line 102, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ org.kitesdk:kite-apps-examples:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-examples/pom.xml, line 83, column 15
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.kitesdk:kite-apps-cli:jar:0.1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ org.kitesdk:kite-apps-cli:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-cli/pom.xml, line 49, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ org.kitesdk:kite-apps-cli:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-cli/pom.xml, line 53, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ org.kitesdk:kite-apps-cli:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-cli/pom.xml, line 36, column 15
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:findbugs-maven-plugin is missing. @ org.kitesdk:kite-apps-cli:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-cli/pom.xml, line 65, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-enforcer-plugin is missing. @ org.kitesdk:kite-apps:0.1.0-SNAPSHOT, /Users/mw010351/git/kite-apps/pom.xml, line 468, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ org.kitesdk:kite-apps-cli:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-cli/pom.xml, line 57, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ org.kitesdk:kite-apps-cli:[unknown-version], /Users/mw010351/git/kite-apps/kite-apps-cli/pom.xml, line 45, column 15
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.kitesdk:kite-apps-tools:pom:0.1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-enforcer-plugin is missing. @ org.kitesdk:kite-apps:0.1.0-SNAPSHOT, /Users/mw010351/git/kite-apps/pom.xml, line 468, column 15
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.kitesdk:kite-apps:pom:0.1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-enforcer-plugin is missing. @ line 468, column 15
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO]
```

This should give you a clean start with no warnings.  Note I followed the pattern you started for the rat plugin for the others but if you don't want them to clutter they can get moved down to the pluginManagement section.
